### PR TITLE
Added numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ libxml2
 libxml2-dev
 libxmlsec1-dev
 libxslt1-dev
+numpy
 p7zip-full
 poppler-utils
 python-all-dev


### PR DESCRIPTION
Because installing numpy with pip leads to disasters ie. non optimized numpy with no blas/lapack or no MKL